### PR TITLE
Set C standard version to C11

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -106,6 +106,7 @@ CFLAGS += -D'USE_HAL_DRIVER'
 CFLAGS += -D'STM32L083xx'
 CFLAGS += -ffunction-sections
 CFLAGS += -fdata-sections
+CFLAGS += -std=c11
 CFLAGS_DEBUG += -g3
 CFLAGS_DEBUG += -Og
 CFLAGS_RELEASE += -Os


### PR DESCRIPTION
arm-none-eabi-gcc (15:4.9.3+svn231177-1) 4.9.3 20150529 (prerelease) which is bundled with Ubuntu 16.04 defaults to ANSI C. ANSI C is missing a lot of features that are used in this codebase causing a lot of build errors and warnings.